### PR TITLE
Ferdigstilt fetch-funksjonalitet

### DIFF
--- a/billettlyst/src/App.jsx
+++ b/billettlyst/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/event/:id" element={<EventPage />} />
+          <Route path="/event/:slug" element={<EventPage />} />
           <Route path="/category/:slug" element={<CategoryPage />} />
           <Route path="/dashboard" element={<Dashboard />} />
         </Routes>

--- a/billettlyst/src/components/EventCard.jsx
+++ b/billettlyst/src/components/EventCard.jsx
@@ -3,13 +3,20 @@ import { Link } from "react-router-dom";
 import "../styles/eventCard.scss";
 
 export default function EventCard({event}) {
+
+    const slugify = (string) => {
+        return string
+            .toLowerCase()
+            .replace(/\s+/g, '-') // Ersatter mellomrom med bindestrek
+            .replace(/[^\w\-]+/g, ''); // Fjerner alt som ikke er bokstaver
+    };
+
     return (
         // Henter ut relevant arrangement-informasjon
         <article className="event-card">
-            <Link to={`/event/${event.id}`} className="event-card-link">
-                <img src={event.images?.[0]?.url} alt="event-image" />
-                <p>{event._embedded?.venues[0]?.city?.name}</p>
-                <h3>{event._embedded?.attractions[0]?.name}</h3>
+            <Link to={`/event/${slugify(event.name)}`} className="event-card-link">
+                <img src={event.images[0]?.url} alt="event-image" />
+                <h3>{event.name}</h3>
             </Link>
         </article>
     )

--- a/billettlyst/src/pages/EventPage.jsx
+++ b/billettlyst/src/pages/EventPage.jsx
@@ -4,11 +4,16 @@ import { useParams } from "react-router-dom";
 import "../styles/eventPage.scss";
 
 export default function EventPage() {
-    const {id} = useParams();
-    const [event, setEvent] = useState(null);
+    const {slug} = useParams();
+    const [event, setEvent] = useState([]);
+
+    const formattedKeyword = (slug) => {
+        return slug.replace(/-/g, " ");
+    }
 
     const getEvent = async() => {
-        fetch(`https://app.ticketmaster.com/discovery/v2/events/${id}.json?&locale=NO&apikey=nwV2iLAvNoKVuQiXYNyXE1lHAr9P850o`)
+        const keyword = formattedKeyword(slug);
+        fetch(`https://app.ticketmaster.com/discovery/v2/events.json?keyword=${keyword}&locale=NO&apikey=nwV2iLAvNoKVuQiXYNyXE1lHAr9P850o`)
             .then(response => response.json())
             .then(data => setEvent(data))
             .catch(error => console.error("Something went wrong fetching event:", error))
@@ -16,13 +21,13 @@ export default function EventPage() {
 
     useEffect(() => {
         getEvent();
-    }, [id]);
+    }, []);
 
     return (
         <section className="event-details-section grid">
-            <img src={event?.images?.[0]?.url} alt="event-image" />
+            <img src={event._embedded?.events[0]?.images[0]?.url} />
             <article>
-                <h1>{event?._embedded?.attractions[0]?.name}</h1>
+                <h1>{event._embedded?.events[0]?._embedded?.attractions[0]?.name}</h1>
             </article>
         </section>
     )

--- a/billettlyst/src/pages/Home.jsx
+++ b/billettlyst/src/pages/Home.jsx
@@ -7,11 +7,12 @@ import "../styles/home.scss";
 export default function Home() {
     // useState-hook som tar imot og holder på arrangement(er)
     const [featuredEvents, setFeaturedEvents] = useState([]);
+    
     // useState-hook som tar imot og holder på arrangementer i en spesifikk by
     const [city, setCity] = useState([]);
 
     // En variabel som inneholder ID-er for fremhevede arrangementer
-    const featuredEventsIds = "Z698xZb_Z16v7eGkFy,Z698xZb_Z17qfaA,Z698xZb_Z17q33_,Z698xZb_Z16vfkqIjU"
+    const featuredIds = "K8vZ917_YJf,K8vZ917K7fV,K8vZ917oWOV,K8vZ917bJC7";
 
     /* 
         - Funksjon som henter arrangementer fra Ticketmaster sin API basert på ID
@@ -19,17 +20,17 @@ export default function Home() {
         - Henter arrangementer i JSON-format ved hjelp av et kall
         - Plasserer hentede arrangementer i state (featuredEvents)
     */
-    const getFeaturedEvents = async(eventIds) => {
-        fetch(`https://app.ticketmaster.com/discovery/v2/events.json?id=${eventIds}&locale=NO&apikey=nwV2iLAvNoKVuQiXYNyXE1lHAr9P850o`)
+    const getFeaturedEvents = async(attractionIds) => {
+        fetch(`https://app.ticketmaster.com/discovery/v2/attractions.json?id=${attractionIds}&locale=NO&apikey=nwV2iLAvNoKVuQiXYNyXE1lHAr9P850o`)
             .then(response => response.json())
-            .then(data => setFeaturedEvents(data._embedded?.events))
+            .then(data => setFeaturedEvents(data._embedded?.attractions))
             .catch(error => console.error("Something went wrong fetching events:", error))
     };
 
     // Funksjonen kjøres når komponentet mountes (rendres)
     useEffect(() => {
         // Benytter "featuredEventsIds" som parameter
-        getFeaturedEvents(featuredEventsIds)
+        getFeaturedEvents(featuredIds)
     }, []);
 
     return (


### PR DESCRIPTION
1) Henter utvalgte arrangementer på attraksjons-id-er

2) Benytter id-ene til å finne navnet på attraksjonen

3) Slugify-er navnene og sender de som en lenke via EventCard

4) Omformaterer navnet (slug) til å passe ny fetch

5) Henter ut arrangement på keyword (slug)